### PR TITLE
rather that throwing a fatal error, return 0 if there is no datasource

### DIFF
--- a/Sources/InfiniteLayout/InfiniteCollectionView.swift
+++ b/Sources/InfiniteLayout/InfiniteCollectionView.swift
@@ -265,7 +265,7 @@ extension InfiniteCollectionView: UICollectionViewDataSource {
 
     private var delegateNumberOfSections: Int {
         guard let sections = dataSourceProxy.delegate.flatMap({ $0.numberOfSections?(in: self) ?? 1 }) else {
-            fatalError("collectionView dataSource is required")
+            return 0
         }
         return sections
     }


### PR DESCRIPTION
To fix a crash, return 0 for number of sections when there is no dataSource